### PR TITLE
Fixed urls used for Readme images to display correctly in Docker Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ To get help on launching and debugging the solutions as containers and switching
 ## Mock Data Recipient - Architecture
 The following diagram outlines the high level architecture of the Mock Data Recipient:
 
-[<img src="./mock-data-recipient-architecture.png?raw=true" height='600' width='600' alt="Mock Data Recipient - Architecture"/>](./mock-data-recipient-architecture.png?raw=true)
+![Mock Data Recipient - Architecture](./mock-data-recipient-architecture.png?raw=true)
 
 Dynamic Client Registration Interface:
 
-[<img src="./mock-data-recipient-dcr-architecture.png?raw=true"  height='240' width='600' alt="Dynamic Client Registration Interface"/>](./mock-data-recipient-dcr-architecture.png?raw=true)
+![Dynamic Client Registration Interface](./mock-data-recipient-dcr-architecture.png?raw=true)
 
 ## Mock Data Recipient - Components
 The Mock Data Recipient contains the following components:


### PR DESCRIPTION
**Checklist:** (Put an `x` in all the boxes that apply)
- [ ] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have checked that there aren't any other open **Pull Requests** from the same change.
- [ ] The `develop` branch has been set as the `base` branch to merge changes of the pull request.
- [ ] I have updated the `CHANGELOG.md` file as appropriate.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
docker hub images fixed


**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?** (if this is a feature change)



**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



**Other information**:
